### PR TITLE
chore: use env interpolation for mail vars in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,11 @@ services:
     ports:
       - "3000:3000"
     environment:
-        - MAIL_SERVER_HOST=
-        - MAIL_SERVER_PORT=
-        - MAIL_SERVER_RECEIVER=
-        - MAIL_SERVER_USER=
-        - MAIL_SERVER_PASSWORD=
+        - MAIL_SERVER_HOST=${MAIL_SERVER_HOST}
+        - MAIL_SERVER_PORT=${MAIL_SERVER_PORT}
+        - MAIL_SERVER_RECEIVER=${MAIL_SERVER_RECEIVER}
+        - MAIL_SERVER_USER=${MAIL_SERVER_USER}
+        - MAIL_SERVER_PASSWORD=${MAIL_SERVER_PASSWORD}
         - REDIS_HOST=redis
         - REDIS_PORT=6379
     depends_on:


### PR DESCRIPTION
## Summary

Coolify only surfaces **editable** environment variables when they're declared in the `VAR=${VAR}` interpolation form. The previous `docker-compose.yml` had empty literals (`MAIL_SERVER_HOST=`), which Coolify treats as fixed/blank and won't let you edit.

Switches the `MAIL_SERVER_*` entries to interpolation so they're managed from the Coolify UI:

```yaml
- MAIL_SERVER_HOST=${MAIL_SERVER_HOST}
- MAIL_SERVER_PORT=${MAIL_SERVER_PORT}
- MAIL_SERVER_RECEIVER=${MAIL_SERVER_RECEIVER}
- MAIL_SERVER_USER=${MAIL_SERVER_USER}
- MAIL_SERVER_PASSWORD=${MAIL_SERVER_PASSWORD}
```

Redis wiring (`REDIS_HOST=redis`, `REDIS_PORT=6379`) stays literal — it's internal service linkage, not user config.

## Verification
- `docker compose config -q` ✅