### PR TITLE
feat: healthcheck endpoint + container HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,8 @@ COPY --from=build /app/public /app/public
 
 EXPOSE 3000
 
+# slim image has no curl/wget — use Node's built-in fetch
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:3000/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
 CMD [ "pnpm", "start" ]

--- a/app/routes/healthz.tsx
+++ b/app/routes/healthz.tsx
@@ -1,0 +1,3 @@
+// Lightweight health endpoint for container/Coolify healthchecks.
+// Resource route (no default export) — does no external calls.
+export const loader = () => new Response('ok', {status: 200});


### PR DESCRIPTION
## Summary

Adds proper healthchecks for Coolify / Docker.

- **`app/routes/healthz.tsx`** — resource route returning `200 ok`, no external calls (won't hit the GitHub API or Redis like `/` would).
- **Dockerfile `HEALTHCHECK`** — uses Node's built-in `fetch` (the `node:lts-slim` base has no curl/wget): `--interval=30s --timeout=5s --start-period=40s --retries=3`.

### Coolify UI
Configuration → Healthcheck: path `/healthz`, port `3000`, interval 30s, timeout 5s, retries 3, start-period 40s.

## Verification
- `pnpm typecheck` ✅
- `docker build .` ✅
- Ran the image: `GET /healthz` → `200`; `docker inspect` health status → **healthy**.