### PR TITLE
fix: don't publish host port (route via Coolify proxy)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,10 @@ services:
   homepage:
     build: .
     restart: unless-stopped
-    ports:
-      - "3000:3000"
+    # Only exposed on the internal network — Coolify's proxy routes to it
+    # via the configured domain. No host port published.
+    expose:
+      - "3000"
     environment:
         - MAIL_SERVER_HOST=${MAIL_SERVER_HOST}
         - MAIL_SERVER_PORT=${MAIL_SERVER_PORT}


### PR DESCRIPTION
## Summary

`ports: "3000:3000"` published the app on the server's **public IP at :3000**, bypassing Coolify's reverse proxy. Replaced with `expose: "3000"` so the container is only reachable on the internal Docker network — Coolify's proxy routes external traffic to it via the configured domain.

```diff
-    ports:
-      - "3000:3000"
+    expose:
+      - "3000"
```

## Coolify
- Make sure the resource has a **Domain** set (e.g. `https://homepage.seikatsu.io`) so the proxy has a route.
- "Ports Exposes" = `3000` (matches `EXPOSE`/`expose`).
- After this, `http://<server-ip>:3000` is no longer reachable; access is via the domain only.

## Verification
- `docker compose config -q` ✅